### PR TITLE
fixed opening link in WSL 

### DIFF
--- a/lua/typst-preview/commands.lua
+++ b/lua/typst-preview/commands.lua
@@ -20,7 +20,7 @@ else
 end
 
 local function visit(link)
-  vim.fn.jobstart(string.format('%s %s', open_cmd, link), {
+  vim.fn.jobstart(string.format('%s http://%s', open_cmd, link), {
     on_stderr = function(_, data)
       local msg = table.concat(data or {}, '\n')
       if msg ~= '' then

--- a/lua/typst-preview/commands.lua
+++ b/lua/typst-preview/commands.lua
@@ -14,7 +14,7 @@ elseif
   fetch.is_windows()
   or (fetch.is_linux() and vim.loop.os_uname().release:lower():find 'microsoft')
 then
-  open_cmd = 'cmd.exe /c start ""'
+  open_cmd = 'explorer.exe'
 else
   open_cmd = 'xdg-open'
 end

--- a/lua/typst-preview/commands.lua
+++ b/lua/typst-preview/commands.lua
@@ -2,33 +2,11 @@ local events = require 'typst-preview.events'
 local fetch = require 'typst-preview.fetch'
 local utils = require 'typst-preview.utils'
 local init = require 'typst-preview.init'
+local server = require 'typst-preview.server'
 
 local M = {}
 
 local previewing = {}
-
-local open_cmd
-if fetch.is_macos() then
-  open_cmd = 'open'
-elseif
-  fetch.is_windows()
-  or (fetch.is_linux() and vim.loop.os_uname().release:lower():find 'microsoft')
-then
-  open_cmd = 'explorer.exe'
-else
-  open_cmd = 'xdg-open'
-end
-
-local function visit(link)
-  vim.fn.jobstart(string.format('%s http://%s', open_cmd, link), {
-    on_stderr = function(_, data)
-      local msg = table.concat(data or {}, '\n')
-      if msg ~= '' then
-        print('typst-preview opening link failed: ' .. msg)
-      end
-    end,
-  })
-end
 
 function M.create_commands()
   local function preview_off(bufnr)
@@ -73,7 +51,7 @@ function M.create_commands()
       end)
     elseif type(previewing[bufnr]) == 'string' then
       print 'Opening another fontend'
-      visit(previewing[bufnr])
+      utils.visit(previewing[bufnr])
     end
   end
 

--- a/lua/typst-preview/commands.lua
+++ b/lua/typst-preview/commands.lua
@@ -2,7 +2,6 @@ local events = require 'typst-preview.events'
 local fetch = require 'typst-preview.fetch'
 local utils = require 'typst-preview.utils'
 local init = require 'typst-preview.init'
-local server = require 'typst-preview.server'
 
 local M = {}
 

--- a/lua/typst-preview/fetch.lua
+++ b/lua/typst-preview/fetch.lua
@@ -9,47 +9,19 @@ local M = {
   websocat_bin_name = nil,
 }
 
-function M.is_windows()
-  return vim.loop.os_uname().sysname == 'Windows_NT'
-end
-
-function M.is_macos()
-  return vim.loop.os_uname().sysname == 'Darwin'
-end
-
-function M.is_linux()
-  return vim.loop.os_uname().sysname == 'Linux'
-end
-
--- Stolen from mason.nvim
-
-function M.is_x64()
-  local machine = vim.loop.os_uname().machine
-  return machine == 'x86_64' or machine == 'x64'
-end
-
-function M.is_arm64()
-  local machine = vim.loop.os_uname().machine
-  return machine == 'aarch64'
-    or machine == 'aarch64_be'
-    or machine == 'armv8b'
-    or machine == 'armv8l'
-    or machine == 'arm64'
-end
-
 local function get_bin_name(map)
   local machine
-  if M.is_x64() then
+  if utils.is_x64() then
     machine = 'x64'
-  elseif M.is_arm64() then
+  elseif utils.is_arm64() then
     machine = 'arm64'
   end
   local os
-  if M.is_macos() then
+  if utils.is_macos() then
     os = 'macos'
-  elseif M.is_linux() then
+  elseif utils.is_linux() then
     os = 'linux'
-  elseif M.is_windows() then
+  elseif utils.is_windows() then
     os = 'windows'
   end
 
@@ -153,7 +125,7 @@ local function download_bin(bin, callback)
         'Downloading ' .. name .. ' binary failed, exit code: ' .. code
       )
     else
-      if not M.is_windows() then
+      if not utils.is_windows() then
         -- Set executable permission
         vim.loop.spawn('chmod', { args = { '+x', path } }, callback)
       else

--- a/lua/typst-preview/server.lua
+++ b/lua/typst-preview/server.lua
@@ -30,6 +30,7 @@ function M.spawn(bufnr, callback, set_link)
   local server_handle, _ =
     assert(vim.loop.spawn(utils.get_data_path() .. fetch.get_typst_bin_name(), {
       args = {
+        '--no-open',
         '--data-plane-host',
         '127.0.0.1:0',
         '--control-plane-host',
@@ -104,6 +105,7 @@ function M.spawn(bufnr, callback, set_link)
       if static_host then
         utils.debug 'Setting link'
         vim.defer_fn(function()
+          utils.visit(static_host)
           set_link(static_host)
         end, 0)
       end

--- a/lua/typst-preview/utils.lua
+++ b/lua/typst-preview/utils.lua
@@ -1,6 +1,70 @@
 local config = require 'typst-preview.config'
 local M = {}
 
+---check if the host system is windows
+function M.is_windows()
+  return vim.loop.os_uname().sysname == 'Windows_NT'
+end
+
+---check if the host system is macos
+function M.is_macos()
+  return vim.loop.os_uname().sysname == 'Darwin'
+end
+
+---check if the host system is linux
+function M.is_linux()
+  return vim.loop.os_uname().sysname == 'Linux'
+end
+
+---check if the host system is wsl
+function M.is_wsl()
+  return M.is_linux() and vim.loop.os_uname().release:lower():find 'microsoft'
+end
+
+-- Stolen from mason.nvim
+
+---check if the host arch is x64
+function M.is_x64()
+  local machine = vim.loop.os_uname().machine
+  return machine == 'x86_64' or machine == 'x64'
+end
+
+---check if the host arch is arm64
+function M.is_arm64()
+  local machine = vim.loop.os_uname().machine
+  return machine == 'aarch64'
+    or machine == 'aarch64_be'
+    or machine == 'armv8b'
+    or machine == 'armv8l'
+    or machine == 'arm64'
+end
+
+local open_cmd
+if M.is_macos() then
+  open_cmd = 'open'
+elseif M.is_windows() then
+  open_cmd = 'explorer.exe'
+elseif M.is_wsl() then
+  open_cmd = '/mnt/c/Windows/explorer.exe'
+else
+  open_cmd = 'xdg-open'
+end
+
+---Open link in browser (platform agnostic)
+---@param link string
+function M.visit(link)
+  local cmd = string.format('%s http://%s', open_cmd, link)
+  M.debug(cmd)
+  vim.fn.jobstart(cmd, {
+    on_stderr = function(_, data)
+      local msg = table.concat(data or {}, '\n')
+      if msg ~= '' then
+        print('typst-preview opening link failed: ' .. msg)
+      end
+    end,
+  })
+end
+
 ---check if a file exist
 ---@param path string
 function M.file_exist(path)

--- a/lua/typst-preview/utils.lua
+++ b/lua/typst-preview/utils.lua
@@ -54,7 +54,7 @@ end
 ---@param link string
 function M.visit(link)
   local cmd = string.format('%s http://%s', open_cmd, link)
-  M.debug(cmd)
+  M.debug('Opening preview with command: ' .. cmd)
   vim.fn.jobstart(cmd, {
     on_stderr = function(_, data)
       local msg = table.concat(data or {}, '\n')


### PR DESCRIPTION
This PR fixes some WSL-related issue I have encountered.

## Link Format
First, Windows on my laptop cannot recognize links like `127.0.0.1:80`. For example, if I run command `cmd.exe /c start "" '127.0.0.1:80'`, the following popup shows.

![image](https://github.com/chomosuke/typst-preview.nvim/assets/74861140/6dd0011e-38c6-4090-9632-f7e92eb2ea64)

However, if I use the link as `http://127.0.0.1:80`, Windows would open a new tab in the browser successfully. So I added `http://` prefix to host link in `find_host()`.

## Open Command in WSL
If I'm in a WSL directory, the command `cmd.exe` would start extremely slow (This would also affect the open command `cmd.exe /c start "" {url}`). For example, the screenshot below shows how slow it is to use `cmd.exe` in a WSL directory (14 seconds in `~` and 0.17 seconds in `/mnt/c`).

![image](https://github.com/chomosuke/typst-preview.nvim/assets/74861140/c0928229-68da-4a43-aea9-c8702d86f1ca)


To solve this, we can use `powershell.exe -Command start "" {url}` or `explorer.exe {url}` instead. I chose `explorer.exe`.