### PR TITLE
fix buffer autocommands bug?

### DIFF
--- a/lua/typst-preview/utils.lua
+++ b/lua/typst-preview/utils.lua
@@ -96,14 +96,12 @@ end
 ---@param name string
 ---@param autocmds { event: string[]|string, opts: AutocmdOpts }[]
 function M.create_autocmds(name, autocmds)
-  vim.defer_fn(function()
-    local id = vim.api.nvim_create_augroup(name, {})
-    for _, autocmd in ipairs(autocmds) do
-      ---@diagnostic disable-next-line: inject-field
-      autocmd.opts.group = id
-      vim.api.nvim_create_autocmd(autocmd.event, autocmd.opts)
-    end
-  end, 0)
+  local id = vim.api.nvim_create_augroup(name, {})
+  for _, autocmd in ipairs(autocmds) do
+    ---@diagnostic disable-next-line: inject-field
+    autocmd.opts.group = id
+    vim.api.nvim_create_autocmd(autocmd.event, autocmd.opts)
+  end
 end
 
 ---print that can be called anywhere


### PR DESCRIPTION
fixes #12 
apparently, removing `vim.defer_fn` from `create_autocmds` fixes this for me, but not sure if it's acceptable as I don't know the original purpose of using a defer here.