### PR TITLE
Add configuration to enable color invert

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ require 'typst-preview'.setup {
   -- Example: open_cmd = 'firefox %s -P typst-preview --class typst-preview'
   open_cmd = nil,
 
+  -- Setting this to always will invert black and white in the preview
+  -- Setting this to auto will invert depending if the browser has enable dark mode
+  invert_colors = "never",
+
   -- This function will be called to determine the root of the typst project
   get_root = function(bufnr_of_typst_buffer)
     return vim.fn.getcwd()

--- a/doc/typst-preview.nvim.txt
+++ b/doc/typst-preview.nvim.txt
@@ -115,6 +115,13 @@ Provide a custom format string to open the output link in `%s`.
 Example value for open_cmd: `'firefox %s -P typst-preview --class typst-preview'`.
   Type: `string`, Default: `nil`
 
+*typst-preview.invert_colors*
+Can be used to invert colors in preview.
+Set to `never` to disable.
+Set to `always` to enable.
+Set to `auto` to enable if environment (usually browser) has enabled darkmode.
+  Type: `string`, Default: `never`
+
 *typst-preview.get_root*
 This function will be called to determine the root of the typst project
 

--- a/lua/typst-preview/config.lua
+++ b/lua/typst-preview/config.lua
@@ -1,6 +1,7 @@
 local M = {
   opts = {
     open_cmd = nil,
+    invert_colors = 'never',
     debug = false,
     get_root = function(_)
       return vim.fn.getcwd()

--- a/lua/typst-preview/server.lua
+++ b/lua/typst-preview/server.lua
@@ -30,6 +30,8 @@ function M.spawn(bufnr, callback, set_link)
   local server_handle, _ =
     assert(vim.loop.spawn(utils.get_data_path() .. fetch.get_typst_bin_name(), {
       args = {
+        '--invert-colors',
+        config.opts.invert_colors,
         '--no-open',
         '--data-plane-host',
         '127.0.0.1:0',


### PR DESCRIPTION
Version 0.10.7 of typst-preview introduced a [new configuration](https://github.com/Enter-tainer/typst-preview/releases/tag/v0.10.7) to invert colors in the preview, this adds it as a configuration option for this plugin.