### PR TITLE
Add ability to provide an executable instead of downloading it

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ require 'typst-preview'.setup {
   -- Example: open_cmd = 'firefox %s -P typst-preview --class typst-preview'
   open_cmd = nil,
 
-  -- Provide name or path to binaries for dependencies.
-  -- Setting this will skip the download of the executable by the plugin.
+  -- Provide the path to binaries for dependencies.
+  -- Setting this will skip the download of the binary by the plugin.
   -- Warning: Be aware that your version might be older than the one
   -- required.
   dependencies_bin = {

--- a/README.md
+++ b/README.md
@@ -83,11 +83,14 @@ require 'typst-preview'.setup {
   -- Example: open_cmd = 'firefox %s -P typst-preview --class typst-preview'
   open_cmd = nil,
 
-  -- Provide name or path to `typst-preview` executable
+  -- Provide name or path to binaries for dependencies.
   -- Setting this will skip the download of the executable by the plugin.
   -- Warning: Be aware that your version might be older than the one
   -- required.
-  executable = nil,
+  dependencies_bin = {
+          ['typst-preview'] = nil,
+          ['websocat'] = nil
+  },
 
   -- Setting this to 'always' will invert black and white in the preview
   -- Setting this to 'auto' will invert depending if the browser has enable

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ require 'typst-preview'.setup {
   -- Example: open_cmd = 'firefox %s -P typst-preview --class typst-preview'
   open_cmd = nil,
 
+  -- Provide name or path to `typst-preview` executable
+  -- Setting this will skip the download of the executable by the plugin.
+  -- Warning: Be aware that your version might be older than the one
+  -- required.
+  executable = nil,
+
   -- Setting this to 'always' will invert black and white in the preview
   -- Setting this to 'auto' will invert depending if the browser has enable
   -- dark mode

--- a/doc/typst-preview.nvim.txt
+++ b/doc/typst-preview.nvim.txt
@@ -115,6 +115,13 @@ Provide a custom format string to open the output link in `%s`.
 Example value for open_cmd: `'firefox %s -P typst-preview --class typst-preview'`.
   Type: `string`, Default: `nil`
 
+*typst-preview.executable*
+Provide name or path to `typst-preview` executable.
+Setting this will skip the download of the executable by the plugin.
+Warning: Be aware that your version might be older than the one
+required.
+  Type: `string`, Default: `nil`
+
 *typst-preview.invert_colors*
 Can be used to invert colors in preview.
 Set to `'never'` to disable.

--- a/doc/typst-preview.nvim.txt
+++ b/doc/typst-preview.nvim.txt
@@ -115,12 +115,12 @@ Provide a custom format string to open the output link in `%s`.
 Example value for open_cmd: `'firefox %s -P typst-preview --class typst-preview'`.
   Type: `string`, Default: `nil`
 
-*typst-preview.executable*
-Provide name or path to `typst-preview` executable.
+*typst-preview.dependencies_bin*
+Provide name or path to binaries for dependencies.
 Setting this will skip the download of the executable by the plugin.
 Warning: Be aware that your version might be older than the one
 required.
-  Type: `string`, Default: `nil`
+  Type: `table`, Default: `{['typst-preview'] = nil, ['websocat'] = nil}`
 
 *typst-preview.invert_colors*
 Can be used to invert colors in preview.

--- a/doc/typst-preview.nvim.txt
+++ b/doc/typst-preview.nvim.txt
@@ -116,8 +116,8 @@ Example value for open_cmd: `'firefox %s -P typst-preview --class typst-preview'
   Type: `string`, Default: `nil`
 
 *typst-preview.dependencies_bin*
-Provide name or path to binaries for dependencies.
-Setting this will skip the download of the executable by the plugin.
+Provide the path to binaries for dependencies.
+Setting this will skip the download of the binary by the plugin.
 Warning: Be aware that your version might be older than the one
 required.
   Type: `table`, Default: `{['typst-preview'] = nil, ['websocat'] = nil}`

--- a/lua/typst-preview/commands.lua
+++ b/lua/typst-preview/commands.lua
@@ -2,6 +2,7 @@ local events = require 'typst-preview.events'
 local fetch = require 'typst-preview.fetch'
 local utils = require 'typst-preview.utils'
 local init = require 'typst-preview.init'
+local config = require 'typst-preview.config'
 
 local M = {}
 
@@ -22,7 +23,9 @@ function M.create_commands()
     local bufnr = vim.fn.bufnr()
     -- check if binaries are available and tell them to fetch first
     for _, bin in pairs(fetch.bins_to_fetch()) do
-      if not fetch.up_to_date(bin) then
+      if
+        not fetch.up_to_date(bin) and not config.opts.dependencies_bin[bin.name]
+      then
         utils.notify(
           bin.name
             .. ' not found or out of date\nPlease run :TypstPreviewUpdate first!',

--- a/lua/typst-preview/config.lua
+++ b/lua/typst-preview/config.lua
@@ -4,8 +4,8 @@ local M = {
     invert_colors = 'never',
     debug = false,
     dependencies_bin = {
-            ['typst-preview'] = nil,
-            ['websocat'] = nil
+      ['typst-preview'] = nil,
+      ['websocat'] = nil,
     },
     get_root = function(_)
       return vim.fn.getcwd()

--- a/lua/typst-preview/config.lua
+++ b/lua/typst-preview/config.lua
@@ -3,7 +3,10 @@ local M = {
     open_cmd = nil,
     invert_colors = 'never',
     debug = false,
-    executable = nil,
+    dependencies_bin = {
+            ['typst-preview'] = nil,
+            ['websocat'] = nil
+    },
     get_root = function(_)
       return vim.fn.getcwd()
     end,

--- a/lua/typst-preview/config.lua
+++ b/lua/typst-preview/config.lua
@@ -3,6 +3,7 @@ local M = {
     open_cmd = nil,
     invert_colors = 'never',
     debug = false,
+    executable = nil,
     get_root = function(_)
       return vim.fn.getcwd()
     end,

--- a/lua/typst-preview/events/communicator.lua
+++ b/lua/typst-preview/events/communicator.lua
@@ -5,7 +5,7 @@
 
 local M = {
   ---@type Comm[]
-  comms = {}
+  comms = {},
 }
 
 ---@return Comm comm

--- a/lua/typst-preview/events/init.lua
+++ b/lua/typst-preview/events/init.lua
@@ -45,7 +45,10 @@ function M.watch(bufnr, set_link)
 
         utils.debug(event['end'][1] .. ' ' .. event['end'][2])
         M.suppress_on_scroll = true
-        vim.api.nvim_win_set_cursor(0, {event['end'][1] + 1, event['end'][2] - 1})
+        vim.api.nvim_win_set_cursor(
+          0,
+          { event['end'][1] + 1, event['end'][2] - 1 }
+        )
         vim.defer_fn(function()
           M.suppress_on_scroll = false
         end, 100)

--- a/lua/typst-preview/fetch.lua
+++ b/lua/typst-preview/fetch.lua
@@ -91,8 +91,12 @@ local record_path = utils.get_data_path() .. 'version_record.txt'
 ---@param bin {name: string, bin_name:string, url: string}
 function M.up_to_date(bin)
   if config.opts.dependencies_bin[bin.name] then
-      utils.print(bin.name .. ' is managed by the user (provided via config.dependencies_bin)' .. '\n')
-      return true
+    utils.print(
+      bin.name
+        .. ' is managed by the user (provided via config.dependencies_bin)'
+        .. '\n'
+    )
+    return true
   end
   local record = io.open(record_path, 'r')
   if record ~= nil then
@@ -159,13 +163,13 @@ function M.bins_to_fetch()
       url = 'https://github.com/Enter-tainer/typst-preview/releases/download/v0.10.8/'
         .. M.get_typst_bin_name(),
       bin_name = M.get_typst_bin_name(),
-      name = 'typst-preview'
+      name = 'typst-preview',
     },
     {
       url = 'https://github.com/vi/websocat/releases/download/v1.12.0/'
         .. M.get_websocat_bin_name(),
       bin_name = M.get_websocat_bin_name(),
-      name = 'websocat'
+      name = 'websocat',
     },
   }
 end
@@ -181,9 +185,9 @@ function M.fetch(callback)
       'All binaries required by typst-preview downloaded to '
         .. utils.get_data_path()
     )
-    local record,err = io.open(record_path, 'w')
+    local record, err = io.open(record_path, 'w')
     if record == nil then
-      error("Can't open record file!: "..err)
+      error("Can't open record file!: " .. err)
     end
     for _, bin in pairs(M.bins_to_fetch()) do
       record:write(bin.url .. '\n')
@@ -192,15 +196,20 @@ function M.fetch(callback)
     callback()
   end
 
-  local function download_bins(bins,callback_)
-      for _, bin in ipairs(bins) do
-            if config.opts.dependencies_bin[bin.name] then
-                utils.print(string.format("Binary for '%s' has been provided in config.",bin.name))
-            else
-                download_bin(bin,function() end)
-            end
+  local function download_bins(bins, callback_)
+    for _, bin in ipairs(bins) do
+      if config.opts.dependencies_bin[bin.name] then
+        utils.print(
+          string.format(
+            "Binary for '%s' has been provided in config.",
+            bin.name
+          )
+        )
+      else
+        download_bin(bin, function() end)
       end
-      callback_()
+    end
+    callback_()
   end
 
   download_bins(M.bins_to_fetch(), finish)

--- a/lua/typst-preview/fetch.lua
+++ b/lua/typst-preview/fetch.lua
@@ -197,19 +197,14 @@ function M.fetch(callback)
   end
 
   local function download_bins(bins, callback_)
-    for _, bin in ipairs(bins) do
-      if config.opts.dependencies_bin[bin.name] then
-        utils.print(
-          string.format(
-            "Binary for '%s' has been provided in config.",
-            bin.name
-          )
-        )
-      else
-        download_bin(bin, function() end)
-      end
+    if #bins == 0 then
+      callback_()
+      return
     end
-    callback_()
+    local bin = table.remove(bins, 1)
+    download_bin(bin, function()
+      download_bins(bins, finish)
+    end)
   end
 
   download_bins(M.bins_to_fetch(), finish)

--- a/lua/typst-preview/fetch.lua
+++ b/lua/typst-preview/fetch.lua
@@ -90,14 +90,6 @@ local record_path = utils.get_data_path() .. 'version_record.txt'
 
 ---@param bin {name: string, bin_name:string, url: string}
 function M.up_to_date(bin)
-  if config.opts.dependencies_bin[bin.name] then
-    print(
-      bin.name
-        .. ' is managed by the user (provided via config.dependencies_bin).\n'
-        .. 'Please ensure manually that it is the correct version.\n'
-    )
-    return true
-  end
   local record = io.open(record_path, 'r')
   if record ~= nil then
     for line in record:lines() do
@@ -112,6 +104,16 @@ end
 
 local function download_bin(bin, callback)
   local path = get_path(bin.bin_name)
+  if config.opts.dependencies_bin[bin.name] then
+    print(
+      "Binary for '"
+        .. bin.name
+        .. "' has been provided in config.\n"
+        .. 'Please ensure manually that it is up to date.\n'
+    )
+    callback()
+    return
+  end
   if M.up_to_date(bin) then
     print(bin.name .. ' already up to date.' .. '\n')
     callback()

--- a/lua/typst-preview/fetch.lua
+++ b/lua/typst-preview/fetch.lua
@@ -91,7 +91,7 @@ local record_path = utils.get_data_path() .. 'version_record.txt'
 ---@param bin {name: string, bin_name:string, url: string}
 function M.up_to_date(bin)
   if config.opts.dependencies_bin[bin.name] then
-    utils.print(
+    print(
       bin.name
         .. ' is managed by the user (provided via config.dependencies_bin).\n'
         .. 'Please ensure manually that it is the correct version.\n'
@@ -113,7 +113,7 @@ end
 local function download_bin(bin, callback)
   local path = get_path(bin.bin_name)
   if M.up_to_date(bin) then
-    utils.print(bin.name .. ' already up to date.' .. '\n')
+    print(bin.name .. ' already up to date.' .. '\n')
     callback()
     return
   end

--- a/lua/typst-preview/fetch.lua
+++ b/lua/typst-preview/fetch.lua
@@ -93,8 +93,8 @@ function M.up_to_date(bin)
   if config.opts.dependencies_bin[bin.name] then
     utils.print(
       bin.name
-        .. ' is managed by the user (provided via config.dependencies_bin)'
-        .. '\n'
+        .. ' is managed by the user (provided via config.dependencies_bin).\n'
+        .. 'Please ensure manually that it is the correct version.\n'
     )
     return true
   end

--- a/lua/typst-preview/init.lua
+++ b/lua/typst-preview/init.lua
@@ -9,10 +9,6 @@ local M = {
   get_follow_cursor = autocmds.get_follow_cursor,
   sync_with_cursor = autocmds.sync_with_cursor,
   update =  function()
-    if config.opts.executable then
-        utils.debug(string.format("Executable '%s' has been provided, please update manually.",config.opts.executable))
-        return
-    end
     fetch.fetch()
   end,
 }

--- a/lua/typst-preview/init.lua
+++ b/lua/typst-preview/init.lua
@@ -1,14 +1,13 @@
 local config = require 'typst-preview.config'
 local autocmds = require 'typst-preview.events.autocmds'
 local fetch = require 'typst-preview.fetch'
-local utils = require 'typst-preview.utils'
 
 local M = {
   setup = config.config,
   set_follow_cursor = autocmds.set_follow_cursor,
   get_follow_cursor = autocmds.get_follow_cursor,
   sync_with_cursor = autocmds.sync_with_cursor,
-  update =  function()
+  update = function()
     fetch.fetch()
   end,
 }

--- a/lua/typst-preview/init.lua
+++ b/lua/typst-preview/init.lua
@@ -1,13 +1,18 @@
 local config = require 'typst-preview.config'
 local autocmds = require 'typst-preview.events.autocmds'
 local fetch = require 'typst-preview.fetch'
+local utils = require 'typst-preview.utils'
 
 local M = {
   setup = config.config,
   set_follow_cursor = autocmds.set_follow_cursor,
   get_follow_cursor = autocmds.get_follow_cursor,
   sync_with_cursor = autocmds.sync_with_cursor,
-  update = function()
+  update =  function()
+    if config.opts.executable then
+        utils.debug(string.format("Executable '%s' has been provided, please update manually.",config.opts.executable))
+        return
+    end
     fetch.fetch()
   end,
 }

--- a/lua/typst-preview/server.lua
+++ b/lua/typst-preview/server.lua
@@ -27,7 +27,7 @@ function M.spawn(bufnr, callback, set_link)
   local file_path = M.get_buffer_path(bufnr)
   local server_stdout = assert(vim.loop.new_pipe())
   local server_stderr = assert(vim.loop.new_pipe())
-  local typst_preview_bin = config.opts.executable and config.opts.executable or ( utils.get_data_path() .. fetch.get_typst_bin_name() )
+  local typst_preview_bin = config.opts.dependencies_bin['typst-preview'] and config.opts.dependencies_bin['typst-preview'] or ( utils.get_data_path() .. fetch.get_typst_bin_name() )
   local server_handle, _ =
     assert(vim.loop.spawn(typst_preview_bin, {
       args = {
@@ -52,8 +52,9 @@ function M.spawn(bufnr, callback, set_link)
     local stdout = assert(vim.loop.new_pipe())
     local stderr = assert(vim.loop.new_pipe())
     local addr = 'ws://' .. host .. '/'
+    local websocat_bin = config.opts.dependencies_bin['websocat'] and config.opts.dependencies_bin['websocat'] or ( utils.get_data_path() .. fetch.get_websocat_bin_name() )
     local websocat_handle, _ = assert(
-      vim.loop.spawn(utils.get_data_path() .. fetch.get_websocat_bin_name(), {
+      vim.loop.spawn(websocat_bin, {
         args = {
           '-B',
           '10000000',

--- a/lua/typst-preview/server.lua
+++ b/lua/typst-preview/server.lua
@@ -27,42 +27,43 @@ function M.spawn(bufnr, callback, set_link)
   local file_path = M.get_buffer_path(bufnr)
   local server_stdout = assert(vim.loop.new_pipe())
   local server_stderr = assert(vim.loop.new_pipe())
-  local typst_preview_bin = config.opts.dependencies_bin['typst-preview'] and config.opts.dependencies_bin['typst-preview'] or ( utils.get_data_path() .. fetch.get_typst_bin_name() )
-  local server_handle, _ =
-    assert(vim.loop.spawn(typst_preview_bin, {
-      args = {
-        '--invert-colors',
-        config.opts.invert_colors,
-        '--no-open',
-        '--data-plane-host',
-        '127.0.0.1:0',
-        '--control-plane-host',
-        '127.0.0.1:0',
-        '--static-file-host',
-        '127.0.0.1:0',
-        '--root',
-        config.opts.get_root(bufnr),
-        file_path,
-      },
-      stdio = { nil, server_stdout, server_stderr },
-    }))
+  local typst_preview_bin = config.opts.dependencies_bin['typst-preview']
+      and config.opts.dependencies_bin['typst-preview']
+    or (utils.get_data_path() .. fetch.get_typst_bin_name())
+  local server_handle, _ = assert(vim.loop.spawn(typst_preview_bin, {
+    args = {
+      '--invert-colors',
+      config.opts.invert_colors,
+      '--no-open',
+      '--data-plane-host',
+      '127.0.0.1:0',
+      '--control-plane-host',
+      '127.0.0.1:0',
+      '--static-file-host',
+      '127.0.0.1:0',
+      '--root',
+      config.opts.get_root(bufnr),
+      file_path,
+    },
+    stdio = { nil, server_stdout, server_stderr },
+  }))
 
   local function connect(host)
     local stdin = assert(vim.loop.new_pipe())
     local stdout = assert(vim.loop.new_pipe())
     local stderr = assert(vim.loop.new_pipe())
     local addr = 'ws://' .. host .. '/'
-    local websocat_bin = config.opts.dependencies_bin['websocat'] and config.opts.dependencies_bin['websocat'] or ( utils.get_data_path() .. fetch.get_websocat_bin_name() )
-    local websocat_handle, _ = assert(
-      vim.loop.spawn(websocat_bin, {
-        args = {
-          '-B',
-          '10000000',
-          addr,
-        },
-        stdio = { stdin, stdout, stderr },
-      })
-    )
+    local websocat_bin = config.opts.dependencies_bin['websocat']
+        and config.opts.dependencies_bin['websocat']
+      or (utils.get_data_path() .. fetch.get_websocat_bin_name())
+    local websocat_handle, _ = assert(vim.loop.spawn(websocat_bin, {
+      args = {
+        '-B',
+        '10000000',
+        addr,
+      },
+      stdio = { stdin, stdout, stderr },
+    }))
     utils.debug('websocat connecting to: ' .. addr)
     stderr:read_start(function(err, data)
       if err then

--- a/lua/typst-preview/server.lua
+++ b/lua/typst-preview/server.lua
@@ -27,8 +27,9 @@ function M.spawn(bufnr, callback, set_link)
   local file_path = M.get_buffer_path(bufnr)
   local server_stdout = assert(vim.loop.new_pipe())
   local server_stderr = assert(vim.loop.new_pipe())
+  local typst_preview_bin = config.opts.executable and config.opts.executable or ( utils.get_data_path() .. fetch.get_typst_bin_name() )
   local server_handle, _ =
-    assert(vim.loop.spawn(utils.get_data_path() .. fetch.get_typst_bin_name(), {
+    assert(vim.loop.spawn(typst_preview_bin, {
       args = {
         '--invert-colors',
         config.opts.invert_colors,

--- a/lua/typst-preview/server.lua
+++ b/lua/typst-preview/server.lua
@@ -28,7 +28,6 @@ function M.spawn(bufnr, callback, set_link)
   local server_stdout = assert(vim.loop.new_pipe())
   local server_stderr = assert(vim.loop.new_pipe())
   local typst_preview_bin = config.opts.dependencies_bin['typst-preview']
-      and config.opts.dependencies_bin['typst-preview']
     or (utils.get_data_path() .. fetch.get_typst_bin_name())
   local server_handle, _ = assert(vim.loop.spawn(typst_preview_bin, {
     args = {
@@ -54,7 +53,6 @@ function M.spawn(bufnr, callback, set_link)
     local stderr = assert(vim.loop.new_pipe())
     local addr = 'ws://' .. host .. '/'
     local websocat_bin = config.opts.dependencies_bin['websocat']
-        and config.opts.dependencies_bin['websocat']
       or (utils.get_data_path() .. fetch.get_websocat_bin_name())
     local websocat_handle, _ = assert(vim.loop.spawn(websocat_bin, {
       args = {


### PR DESCRIPTION
```
Watching buffer: 2                                                                            
Could not start dynamically linked executable: /home/inferno/.local/share/nvim/typst-preview/t
ypst-preview-linux-x64                                                                        
NixOS cannot run dynamically linked executables intended for generic                          
linux environments out of the box. For more information, see:                                 
https://nix.dev/permalink/stub-ld       
```
Was getting the above error on NixOs , so i decided to add a way to provide your own executable
Closes #15 