### PR TITLE
Bump typst-preview version to 0.11.2

### DIFF
--- a/lua/typst-preview/fetch.lua
+++ b/lua/typst-preview/fetch.lua
@@ -162,7 +162,7 @@ end
 function M.bins_to_fetch()
   return {
     {
-      url = 'https://github.com/Enter-tainer/typst-preview/releases/download/v0.10.8/'
+      url = 'https://github.com/Enter-tainer/typst-preview/releases/download/v0.11.2/'
         .. M.get_typst_bin_name(),
       bin_name = M.get_typst_bin_name(),
       name = 'typst-preview',


### PR DESCRIPTION
This PR will update `typst` minor version to latest (0.11.x).
This is so that it is compatible with the latest version of `typst`.

Perhaps it might be possible to target different versions of `typst` in the future?
According to [https://github.com/Enter-tainer/typst-preview/releases/](https://github.com/Enter-tainer/typst-preview/releases/), this is the latest release version.

Please let me know if I did this incorrectly, and I hope this PR is a welcome change! :)