### PR TITLE
Add mode argument to :TypstPreview to support slide mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Plug 'chomosuke/typst-preview.nvim', {'tag': 'v0.1.*', do: ':TypstPreviewUpdate'
     - If you followed the installation instructions, your package manager should automatically run
       this for you.
 - `:TypstPreview`:
-  - Start the preview.
+  - Start the preview. Optionally, the desired preview mode can be specified:
+    `:TypstPreview document` (default) or `:TypstPreview slide` for slide mode.
 - `:TypstPreviewStop`:
   - Stop the preview.
 - `:TypstPreviewToggle`:

--- a/lua/typst-preview/commands.lua
+++ b/lua/typst-preview/commands.lua
@@ -7,6 +7,7 @@ local config = require 'typst-preview.config'
 local M = {}
 
 local previewing = {}
+local previewing_mode = {}
 
 function M.create_commands()
   local function preview_off(bufnr)
@@ -19,7 +20,7 @@ function M.create_commands()
     end
   end
 
-  local function preview_on()
+  local function preview_on(mode)
     local bufnr = vim.fn.bufnr()
     -- check if binaries are available and tell them to fetch first
     for _, bin in pairs(fetch.bins_to_fetch()) do
@@ -35,7 +36,7 @@ function M.create_commands()
       end
     end
 
-    if not previewing[bufnr] then
+    local function start_preview()
       utils.create_autocmds('typst-preview-autocmds-unload-' .. bufnr, {
         {
           event = 'BufUnload',
@@ -49,26 +50,67 @@ function M.create_commands()
         },
       })
       previewing[bufnr] = true
-      events.watch(bufnr, function(link)
+      previewing_mode[bufnr] = mode
+      events.watch(bufnr, mode, function(link)
         previewing[bufnr] = link
       end)
+    end
+
+    if not previewing[bufnr] then
+      start_preview()
     elseif type(previewing[bufnr]) == 'string' then
-      print 'Opening another frontend'
-      utils.visit(previewing[bufnr])
+      if previewing_mode[bufnr] == mode then
+        print 'Opening another frontend'
+        utils.visit(previewing[bufnr])
+      else
+        print ('Re-starting preview with new mode ' .. mode)
+        events.stop(bufnr)
+        start_preview()
+      end
     end
   end
 
   vim.api.nvim_create_user_command('TypstPreviewUpdate', init.update, {})
 
-  vim.api.nvim_create_user_command('TypstPreview', preview_on, {})
+  vim.api.nvim_create_user_command(
+    'TypstPreview',
+    function(opts)
+      local mode = 'document'
+      if #opts.fargs == 0 then
+        -- Use default mode
+      elseif #opts.fargs == 1 then
+        mode = opts.fargs[1]
+        if mode ~= 'document' and mode ~= 'slide'  then
+          utils.notify(
+            'Invalid preview mode: "' .. mode .. '.'
+            .. ' Should be one of "document" and "slide"',
+            vim.log.levels.ERROR
+          )
+          return
+        end
+      else
+        -- Error already handled by nvim, via the `nargs = '?'` below
+        return
+      end
+
+      preview_on(mode)
+    end,
+    { nargs = '?' }
+  )
   vim.api.nvim_create_user_command('TypstPreviewStop', function()
     preview_off()
   end, {})
   vim.api.nvim_create_user_command('TypstPreviewToggle', function()
-    if previewing[vim.fn.bufnr()] then
+    local bufnr = vim.fn.bufnr()
+    if previewing[bufnr] then
       preview_off()
     else
-      preview_on()
+      -- use the previous preview mode, if there was a :TypstPreview call before
+      local mode = previewing_mode[bufnr]
+      if mode == nil then
+        mode = 'document'
+      end
+      preview_on(mode)
     end
   end, {})
 

--- a/lua/typst-preview/events/init.lua
+++ b/lua/typst-preview/events/init.lua
@@ -12,14 +12,14 @@ local M = {
 ---Do all work necessary to start a preview for a buffer.
 ---@param bufnr integer
 ---@param set_link function
-function M.watch(bufnr, set_link)
+function M.watch(bufnr, mode, set_link)
   utils.debug('Watching buffer: ' .. bufnr)
 
   if bufnr == 0 then
     bufnr = vim.fn.bufnr()
   end
 
-  server.spawn(bufnr, function(close_server, write, read_start)
+  server.spawn(bufnr, mode, function(close_server, write, read_start)
     local comm = communicator.new(close_server, write, read_start)
     communicator.comms[bufnr] = comm
 

--- a/lua/typst-preview/server.lua
+++ b/lua/typst-preview/server.lua
@@ -20,10 +20,11 @@ end
 
 ---Spawn the server and connect to it using the websocat process
 ---@param bufnr integer
+---@param mode string preview mode, "document" (default) or "slide"
 ---@param callback function Called after server spawn completes, parameter is
 --(close, write, read_start)
 ---@param set_link function
-function M.spawn(bufnr, callback, set_link)
+function M.spawn(bufnr, mode, callback, set_link)
   local file_path = M.get_buffer_path(bufnr)
   local server_stdout = assert(vim.loop.new_pipe())
   local server_stderr = assert(vim.loop.new_pipe())
@@ -40,6 +41,8 @@ function M.spawn(bufnr, callback, set_link)
       '127.0.0.1:0',
       '--static-file-host',
       '127.0.0.1:0',
+      '--preview-mode',
+      mode,
       '--root',
       config.opts.get_root(bufnr),
       file_path,


### PR DESCRIPTION
This augments the `:TypstPreview` command such that it supports the different preview modes from [Enter-tainer/typst-preview](https://github.com/Enter-tainer/typst-preview/issues):

- `:TypstPreview` is the same as before
- `:TypstPreview document` is equivalent to `:TypstPreview`
- `:TypstPreview slide` opens the server in slide mode

I know only a minimal amount of lua and the nvim API, let me know if I implemented anything in an usual way!

A possible future improvement could be to check whether the document seems to be using `polylux` and choose the default mode accordingly.