### PR TITLE
Bump typst-preview to 0.11.4

### DIFF
--- a/lua/typst-preview/fetch.lua
+++ b/lua/typst-preview/fetch.lua
@@ -162,7 +162,7 @@ end
 function M.bins_to_fetch()
   return {
     {
-      url = 'https://github.com/Enter-tainer/typst-preview/releases/download/v0.11.2/'
+      url = 'https://github.com/Enter-tainer/typst-preview/releases/download/v0.11.4/'
         .. M.get_typst_bin_name(),
       bin_name = M.get_typst_bin_name(),
       name = 'typst-preview',


### PR DESCRIPTION
Bumps `typst-preview` to the latest release.