### PR TITLE
Custom Port

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ require 'typst-preview'.setup {
   -- Example: open_cmd = 'firefox %s -P typst-preview --class typst-preview'
   open_cmd = nil,
 
+  -- Custom port to open the preview server. Default is random.
+  -- Example: port = 8000
+  port = 0,
+
   -- Setting this to 'always' will invert black and white in the preview
   -- Setting this to 'auto' will invert depending if the browser has enable
   -- dark mode

--- a/doc/typst-preview.nvim.txt
+++ b/doc/typst-preview.nvim.txt
@@ -126,6 +126,11 @@ Provide a custom format string to open the output link in `%s`.
 Example value for open_cmd: `'firefox %s -P typst-preview --class typst-preview'`.
   Type: `string`, Default: `nil`
 
+*typst-preview.port*
+Provide a custom port for the preview server. If the port  (e.g. 8000) is
+already in use, the plugin will try to use the next port (e.g. 8001).
+  Type: `number`, Default: `0` (i.e. random)
+
 *typst-preview.invert_colors*
 Can be used to invert colors in preview.
 Set to `'never'` to disable.

--- a/lua/typst-preview/config.lua
+++ b/lua/typst-preview/config.lua
@@ -2,6 +2,7 @@ local M = {
   opts = {
     debug = false,
     open_cmd = nil,
+    port = 0, -- tinymist will use a random port if this is 0
     invert_colors = 'never',
     follow_cursor = true,
     dependencies_bin = {


### PR DESCRIPTION
Passing `--static-file-host 127.0.0.1:0` as arguments to the typst preview binary will start the preview local server on a random port. This PR adds an option to the config that allows a user-specified port instead of a random one.

resolves #33