### PR TITLE
feat: allow configuration of extra args

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ require 'typst-preview'.setup {
     ['websocat'] = nil
   },
 
+  -- A list of extra arguments (or nil) to be passed to previewer.
+  -- For example, extra_args = { "--input=ver=draft", "--ignore-system-fonts" }
+  extra_args = nil,
+
   -- This function will be called to determine the root of the typst project
   get_root = function(path_of_main_file)
     return vim.fn.fnamemodify(path_of_main_file, ':p:h')

--- a/doc/typst-preview.nvim.txt
+++ b/doc/typst-preview.nvim.txt
@@ -144,6 +144,11 @@ Warning: Be aware that your version might be older than the one
 required.
   Type: `table`, Default: `{['typst-preview'] = nil, ['websocat'] = nil}`
 
+*typst-preview.extra_args*
+A list of extra arguments (or nil) to be passed to previewer.
+For example, `{ "--input=ver=draft", "--ignore-system-fonts" }`
+  Type: `table`, Default: `nil`
+
 *typst-preview.get_main_file*
 This function will be called to determine the main file of the typst project
 

--- a/lua/typst-preview/config.lua
+++ b/lua/typst-preview/config.lua
@@ -8,6 +8,7 @@ local M = {
       ['typst-preview'] = nil,
       ['websocat'] = nil,
     },
+    extra_args = nil,
     get_root = function(path)
       return vim.fn.fnamemodify(path, ':p:h')
     end,

--- a/lua/typst-preview/servers/factory.lua
+++ b/lua/typst-preview/servers/factory.lua
@@ -35,6 +35,13 @@ local function spawn(path, mode, callback)
   if typst_preview_bin:find 'tinymist' then
     table.insert(args, 1, 'preview')
   end
+
+  if config.opts.extra_args ~= nil then
+    for _, v in ipairs(config.opts.extra_args) do
+      table.insert(args, v)
+    end
+  end
+
   local server_handle, _ = assert(vim.loop.spawn(typst_preview_bin, {
     args = args,
     stdio = { nil, server_stdout, server_stderr },


### PR DESCRIPTION
allow configuration of extra server command arguments to, for example, set inputs for typst