### PR TITLE
Download binaries automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ https://github.com/chomosuke/typst-preview.nvim/assets/38484873/9f8ecf0f-aa1c-4e
   'chomosuke/typst-preview.nvim',
   lazy = false, -- or ft = 'typst'
   version = '1.*',
-  build = function() require 'typst-preview'.update() end,
 }
 ```
 

--- a/lua/typst-preview/commands.lua
+++ b/lua/typst-preview/commands.lua
@@ -37,16 +37,20 @@ function M.create_commands()
 
   ---@param mode mode?
   local function preview_on(mode)
-    -- check if binaries are available and tell them to fetch first
+    -- Check for missing or outdated binaries
     for _, bin in pairs(fetch.bins_to_fetch()) do
       if
         not fetch.up_to_date(bin) and not config.opts.dependencies_bin[bin.name]
       then
         utils.notify(
-          bin.name
-            .. ' not found or out of date\nPlease run :TypstPreviewUpdate first!',
-          vim.log.levels.ERROR
+          string.format("The binary '%s' is missing or outdated", bin.name),
+          vim.log.levels.WARN
         )
+        utils.notify(
+          'Downloading the required binaries\nPlease rerun the preview command once the download is complete',
+          vim.log.levels.INFO
+        )
+        fetch.fetch(nil)
         return
       end
     end


### PR DESCRIPTION
## Summary

According to https://github.com/folke/lazy.nvim/issues/1806, the `setup` function is not executed during the initial plugin installation. Instead, it only runs when the plugin is updated.

## Details

This behavior can cause issues when configuring plugins with binaries that need to be downloaded or dependencies that must be set up during the initial installation.

Example:
```lua
{
  "chomosuke/typst-preview.nvim",
  cmd = { "TypstPreview", "TypstPreviewToggle", "TypstPreviewUpdate" },
  build = function() require 'typst-preview'.update() end,
  -- The `build` function downloads `tinymist` and `websocat` during an update, 
  -- but `dependencies_bin.tinymist` is not available when the plugin is first installed.
  keys = {
    {
      "<leader>cp",
      ft = "typst",
      "<cmd>TypstPreviewToggle<cr>",
      desc = "Toggle Typst Preview",
    },
  },
  opts = {
    dependencies_bin = {
      tinymist = "tinymist", -- Downloaded by mason.nvim
    },
  },
}
```

## Changes made

- Download the binaries when running the preview command
- Updated the README, remove the `build` in `lazy.nvim` guide

Closes #67 