### PR TITLE
running update() in setup() instead of upon updating the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ https://github.com/chomosuke/typst-preview.nvim/assets/38484873/9f8ecf0f-aa1c-4e
   'chomosuke/typst-preview.nvim',
   lazy = false, -- or ft = 'typst'
   version = '1.*',
-  build = function() require 'typst-preview'.update() end,
+  config = function()
+    require 'typst-preview'.setup {}
+  end,
 }
 ```
 
@@ -36,7 +38,9 @@ https://github.com/chomosuke/typst-preview.nvim/assets/38484873/9f8ecf0f-aa1c-4e
 use {
   'chomosuke/typst-preview.nvim',
   tag = 'v1.*',
-  run = function() require 'typst-preview'.update() end,
+  config = function()
+    require 'typst-preview'.setup {}
+  end,
 }
 ```
 
@@ -80,7 +84,9 @@ plugin, i.e., `v1.1.*` instead of `v1.*`.
 
 ## ⚙️ Configuration
 
-This plugin should work out of the box with no configuration. Call to `setup()` is not required.
+This plugin should work out of the box with no configuration. However, calling
+`setup()` is required to ensure that the binaries that the plugin depends on are
+downloaded and up to date.
 
 ### Default
 

--- a/lua/typst-preview/commands.lua
+++ b/lua/typst-preview/commands.lua
@@ -71,7 +71,7 @@ function M.create_commands()
   end
 
   vim.api.nvim_create_user_command('TypstPreviewUpdate', function()
-    fetch.fetch(nil)
+    fetch.fetch(false)
   end, {})
 
   vim.api.nvim_create_user_command('TypstPreview', function(opts)

--- a/lua/typst-preview/init.lua
+++ b/lua/typst-preview/init.lua
@@ -3,12 +3,15 @@ local fetch = require 'typst-preview.fetch'
 local commands = require 'typst-preview.commands'
 
 local M = {
-  setup = config.config,
+  setup = function()
+    config.config()
+    fetch.fetch(true)
+  end,
   set_follow_cursor = config.set_follow_cursor,
   get_follow_cursor = config.get_follow_cursor,
   sync_with_cursor = commands.sync_with_cursor,
   update = function()
-    fetch.fetch(nil)
+    fetch.fetch(false)
   end,
 }
 


### PR DESCRIPTION
Since `update()` only downloads when the binaries are out of date, this have very little effect on user experience.

Closes #67 