### PR TITLE
conf(partial_rendering): add option for partial rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ require 'typst-preview'.setup {
   -- Example: port = 8000
   port = 0,
 
+  -- Enable partial rendering or not
+  partial_rendering = true,
+
   -- Setting this to 'always' will invert black and white in the preview
   -- Setting this to 'auto' will invert depending if the browser has enable
   -- dark mode

--- a/doc/typst-preview.nvim.txt
+++ b/doc/typst-preview.nvim.txt
@@ -131,6 +131,10 @@ Provide a custom port for the preview server. If the port  (e.g. 8000) is
 already in use, the plugin will try to use the next port (e.g. 8001).
   Type: `number`, Default: `0` (i.e. random)
 
+*typst-preview.partial_rendering*
+Set this to false to disable partial rendering.
+  Type: `boolean`, Default: `true`
+
 *typst-preview.invert_colors*
 Can be used to invert colors in preview.
 Set to `'never'` to disable.

--- a/lua/typst-preview/config.lua
+++ b/lua/typst-preview/config.lua
@@ -3,6 +3,7 @@ local M = {
     debug = false,
     open_cmd = nil,
     port = 0, -- tinymist will use a random port if this is 0
+    partial_rendering = true,
     invert_colors = 'never',
     follow_cursor = true,
     dependencies_bin = {

--- a/lua/typst-preview/servers/factory.lua
+++ b/lua/typst-preview/servers/factory.lua
@@ -17,7 +17,6 @@ local function spawn(path, port, mode, callback)
       or (utils.get_data_path() .. fetch.get_tinymist_bin_name())
   local args = {
     'preview',
-    '--partial-rendering',
     '--invert-colors',
     config.opts.invert_colors,
     '--preview-mode',
@@ -33,6 +32,10 @@ local function spawn(path, port, mode, callback)
     config.opts.get_root(path),
     config.opts.get_main_file(path),
   }
+
+  if config.opts.partial_rendering then
+    table.insert(args, '--partial-rendering')
+  end
 
   if config.opts.extra_args ~= nil then
     for _, v in ipairs(config.opts.extra_args) do

--- a/lua/typst-preview/servers/factory.lua
+++ b/lua/typst-preview/servers/factory.lua
@@ -30,7 +30,6 @@ local function spawn(path, port, mode, callback)
     '127.0.0.1:' .. port,
     '--root',
     config.opts.get_root(path),
-    config.opts.get_main_file(path),
   }
 
   if config.opts.partial_rendering then
@@ -42,6 +41,8 @@ local function spawn(path, port, mode, callback)
       table.insert(args, v)
     end
   end
+
+  table.insert(args, config.opts.get_main_file(path))
 
   local server_handle, _ = assert(vim.uv.spawn(tinymist_bin, {
     args = args,


### PR DESCRIPTION
Add a toggle for partial rendering, default to enabled.

Thanks for this good tool. I encountered some scenarios in which partial rendering causes missing content. The preview is correct when this option is omitted. Adding a config entry should help in edge cases.