### PR TITLE
Escaping edited file name

### DIFF
--- a/lua/typst-preview/events/server.lua
+++ b/lua/typst-preview/events/server.lua
@@ -33,7 +33,7 @@ function M.add_listeners(s)
     end
 
     if event.filepath ~= utils.get_buf_path(0) then
-      vim.cmd('e ' .. event.filepath)
+      vim.cmd('e ' .. vim.fn.fnameescape(event.filepath))
       vim.defer_fn(editorScrollTo, 100)
     else
       editorScrollTo()


### PR DESCRIPTION
When clicking in the previewed document, the plugin will automatically open the filename of the text that was clicked. If this file name was to contain backtick characters, these would be interpreted as the `edit` vim command treats backticks as command execution characters. For example,

```
edit `whoami`
```

would execute the command `whoami`.

This change escapes the file name before opening it.