### PR TITLE
Use proper `open_cmd` on Windows and WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ require 'typst-preview'.setup {
   -- Warning: Be aware that your version might be older than the one
   -- required.
   dependencies_bin = {
-    ['tinymist'] = nil,
-    ['websocat'] = nil
+    tinymist = nil,
+    websocat = nil
   },
 
   -- A list of extra arguments (or nil) to be passed to previewer.
@@ -157,7 +157,8 @@ require 'typst-preview'.setup {
 
 ### Use tinymist installed from Mason
 Set `dependencies_bin` option to
-`dependencies_bin = { ['tinymist'] = 'tinymist' }` should point towards the
+`dependencies_bin = { tinymist = 'tinymist' }` or, on Windows
+`dependencies_bin = { tinymist = 'tinymist.cmd' }` should point towards the
 Mason installation of tinymist.
 
 ## ❓ Comparison with other tools

--- a/lua/typst-preview/utils.lua
+++ b/lua/typst-preview/utils.lua
@@ -33,19 +33,19 @@ end
 function M.is_arm64()
   local machine = vim.uv.os_uname().machine
   return machine == 'aarch64'
-      or machine == 'aarch64_be'
-      or machine == 'armv8b'
-      or machine == 'armv8l'
-      or machine == 'arm64'
+    or machine == 'aarch64_be'
+    or machine == 'armv8b'
+    or machine == 'armv8l'
+    or machine == 'arm64'
 end
 
 local open_cmd
 if M.is_macos() then
   open_cmd = 'open'
 elseif M.is_windows() then
-  open_cmd = 'explorer.exe'
+  open_cmd = 'start'
 elseif M.is_wsl() then
-  open_cmd = '/mnt/c/Windows/explorer.exe'
+  open_cmd = 'wslview'
 else
   open_cmd = 'xdg-open'
 end
@@ -129,7 +129,7 @@ function M.debug(data)
   if config.opts.debug then
     local err
     if file == nil then
-      file, err = io.open(M.log_path, "a")
+      file, err = io.open(M.log_path, 'a')
     end
     if file == nil then
       error("Can't open record file!: " .. err)


### PR DESCRIPTION
Fix #124 

The `open_cmd` is set to following value:
- `start` on Windows, works if default shell is `cmd`, `powershell` or `pwsh`
- `wslview` on WSL, requires `wslu` installation

Added documentation about `.cmd` need to be specified on Windows: https://github.com/mason-org/mason.nvim/pull/2021#issuecomment-3343811679