### PR TITLE
Enable partial rendering by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ require 'typst-preview'.setup {
   -- separately.
   invert_colors = 'never',
 
+  -- Only render the visible portion of the document.
+  -- Improves performance significantly for large documents.
+  -- Disable if you experience rendering issues.
+  partial_rendering = true,
+
   -- Whether the preview will follow the cursor in the source file
   follow_cursor = true,
 

--- a/lua/typst-preview/config.lua
+++ b/lua/typst-preview/config.lua
@@ -12,6 +12,7 @@ local M = {
       ['tinymist'] = nil,
       ['websocat'] = nil,
     },
+    partial_rendering = true,
     extra_args = nil,
     get_root = function(path_of_main_file)
       local env_root = os.getenv 'TYPST_ROOT'

--- a/lua/typst-preview/servers/factory.lua
+++ b/lua/typst-preview/servers/factory.lua
@@ -32,6 +32,10 @@ local function spawn(path, host, port, mode, callback)
     config.opts.get_root(path),
   }
 
+  if config.opts.partial_rendering then
+    table.insert(args, '--partial-rendering=true')
+  end
+
   if config.opts.extra_args ~= nil then
     local extra = config.opts.extra_args
     if type(extra) == 'function' then


### PR DESCRIPTION
Closes #131 

This adds `partial_rendering` to the config and defaults it to `true`. If set, the plugin will launch tinymist with the `--partial-rendering=true` option.

This matches [the default LSP setting](https://myriad-dreamin.github.io/tinymist/config/neovim.html#label-preview.partialRendering) and is recommended although the setting is defined as experimental.