### PR TITLE
fix: add --verbose to tinymist to fix silent preview failure

### DIFF
--- a/lua/typst-preview/servers/factory.lua
+++ b/lua/typst-preview/servers/factory.lua
@@ -22,6 +22,7 @@ local function spawn(path, host, port, mode, callback)
     '--preview-mode',
     mode,
     '--no-open',
+    '--verbose',
     '--data-plane-host',
     host .. ':0',
     '--control-plane-host',


### PR DESCRIPTION
This pull request fixes an issue where the preview server fails to open the browser out of the box when used with `tinymist` >= `0.14.x`. 

- Starting with `0.14.x`, `tinymist` hides `INFO` logs by default. 
- Because `typst-preview.nvim` parses the terminal output for the `INFO` log `Static file server listening on: ` to capture the preview URL, it currently hangs indefinitely and fails to call `utils.visit()`.
- This fix simply adds the `--verbose` flag to the `tinymist preview` invocation in `factory.lua` so the required logs are emitted again.

Tested locally with `tinymist 0.14.21` and it successfully restores the automatic browser launch.